### PR TITLE
ci: standardize workflows using SciML's reusable workflows

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,13 @@
+name: "Format Check"
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags: '*'
+  pull_request:
+
+jobs:
+  format-check:
+    name: "Format Check"
+    uses: "SciML/.github/.github/workflows/format-suggestions-on-pr.yml@v1"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,41 +1,39 @@
-name: CI
+name: "Tests"
+
 on:
+  pull_request:
+    branches:
+      - main
+      - 'release-'
+    paths-ignore:
+      - 'docs/**'
   push:
     branches:
       - main
-    tags: ['*']
-  pull_request:
-  workflow_dispatch:
+    paths-ignore:
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
+    name: "Tests"
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1'
-          # - '1.10' TODO: maybe add this back when 1.10 is no longer latest
           - 'nightly'
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
-        with:
-          files: lcov.info
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      julia-arch: "${{ matrix.arch }}"
+    secrets: "inherit"
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the workflows in this repository to use SciML's reusable workflows.
This is part of a larger effort to standardize the SciML's CI workflows for more generic and common requirements, to keep the workflows uniform and easier to maintain.