### PR TITLE
Canonicalize tests to @safetestset for module isolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [compat]
 Aqua = "0.8"
+SafeTestsets = "0.1, 1"
 SymbolicUtils = "4"
 TermInterface = "2.0"
 Test = "1"
@@ -17,7 +18,8 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Pkg", "Test"]
+test = ["Aqua", "Pkg", "SafeTestsets", "Test"]

--- a/test/development_phase_1.jl
+++ b/test/development_phase_1.jl
@@ -1,0 +1,100 @@
+using SymbolicLimits, SymbolicUtils
+using Test
+
+let
+    @syms x::Real y::Real ω::Real
+    @test SymbolicLimits.zero_equivalence(x * (x + y) - x - x * y + x - x * (x + 1) + x, Set{Any}())
+    @test_broken SymbolicLimits.zero_equivalence(exp((x + 1) * x - x * x - x) - 1, Set{Any}())
+
+    @test SymbolicLimits.get_leading_exponent(x^2, x, nothing, Set{Any}()) == 2
+    @test SymbolicLimits.get_series_term(log(exp(x)), x, nothing, 1, Set{Any}()) ==
+        1
+    @test SymbolicLimits.get_series_term(log(exp(x)), x, -x, 0, Set{Any}()) == 0
+    @test SymbolicLimits.get_series_term(log(exp(x)), x, nothing, 2, Set{Any}()) ==
+        0
+
+    # F = exp(x+exp(-x))-exp(x)
+    # Ω = {exp(x + exp(-x)), exp(x), exp(-x)}
+    # Topo-sort Ω by containment
+    # Take a smallest element of Ω and call it ω.
+    # ω = exp(-x)
+    # From largest to smallest, rewrite elements f ∈ Ω in terms of ω in the form
+    # Assume f is of the form exp(s) and ω is of the form exp(t).
+    # -- Recursively compute c = lim(s/t)
+    # f = f*ω^c/ω^c = exp(log(f)-c*log(ω))*ω^c = exp(s-ct)*ω^c
+
+    # f = exp(x+exp(-x))
+    # s = x+exp(-x)
+    # t = -x
+    # c = lim(s/t) = lim((x+exp(-x))/-x) = -1
+    # f = exp(s-ct)*ω^c = exp(x+exp(-x)-c*t)*ω^-1 = exp(exp(-x))/ω
+
+    @test SymbolicLimits.zero_equivalence(
+        SymbolicLimits.rewrite(exp(x + exp(-x)), ω, -x, x, Set{Any}()) -
+            exp(exp(-x)) / ω,
+        Set{Any}()
+    ) # it works if you define `limit(args...) = -1`
+
+    # F = exp(exp(-x))/ω - exp(x)
+
+    # f = exp(x)
+    # s = x
+    # t = -x
+    # c = -1
+    # f = exp(s-ct)*ω^c = exp(x-c*t)*ω^-1 = exp(0)/ω = 1/ω
+
+    # F = exp(exp(-x))/ω - 1/ω
+
+    # ...
+
+    # F = exp(ω)/ω - 1/ω
+    let F = exp(ω) / ω - 1 / ω, h = -x
+        @test SymbolicLimits.get_leading_exponent(F, ω, h, Set{Any}()) == 0
+        @test SymbolicLimits.get_series_term(F, ω, h, 0, Set{Any}()) == 1 # the correct final answer
+    end
+
+    function test(expr, leading_exp, series, sym = x)
+        lt = SymbolicLimits.get_leading_exponent(expr, sym, nothing, Set{Any}())
+        @test lt === leading_exp
+        for (i, val) in enumerate(series)
+            @test SymbolicLimits.get_series_term(
+                expr, sym, nothing, lt + i - 1, Set{Any}()
+            ) === val
+        end
+        for i in (leading_exp - 10):(leading_exp - 1)
+            @test SymbolicLimits.get_series_term(
+                expr, sym, nothing, i, Set{Any}()
+            ) === 0
+        end
+        return
+    end
+    test(x, 1, [1, 0, 0, 0, 0, 0])
+    test(x^2, 2, [1, 0, 0, 0, 0, 0])
+    test(x^2 + x, 1, [1, 1, 0, 0, 0, 0])
+
+    @test SymbolicLimits.recursive([1, [2, 3]]) do f, arg
+        arg isa AbstractArray ? sum(f, arg) : arg
+    end == 6
+
+    @test unwrap_const(
+        only(SymbolicLimits.most_rapidly_varying_subexpressions(exp(x), x, Set{Any}())) -
+            exp(x)
+    ) === 0 # works if you define `limit(args...) = Inf`
+    @test all(i -> i === x, SymbolicLimits.most_rapidly_varying_subexpressions(x + 2(x + 1), x, Set{Any}())) # works if you define `limit(args...) = 1`
+
+    @test SymbolicLimits.log_exp_simplify(x) === x
+    @test SymbolicLimits.zero_equivalence(
+        SymbolicLimits.log_exp_simplify(exp(x)) -
+            exp(x), Set{Any}()
+    )
+    @test SymbolicLimits.zero_equivalence(
+        SymbolicLimits.log_exp_simplify(exp(log(x))) - exp(log(x)), Set{Any}()
+    )
+    @test SymbolicLimits.log_exp_simplify(log(exp(x))) === x
+    @test SymbolicLimits.zero_equivalence(
+        SymbolicLimits.log_exp_simplify(log(exp(log(x)))) - log(x), Set{Any}()
+    )
+    @test unwrap_const(SymbolicLimits.log_exp_simplify(log(exp(1 + x))) - (1 + x)) === 0
+    @test SymbolicLimits.log_exp_simplify(log(log(exp(exp(x))))) === x
+    @test SymbolicLimits.log_exp_simplify(log(exp(log(exp(x))))) === x
+end

--- a/test/development_phase_2.jl
+++ b/test/development_phase_2.jl
@@ -1,0 +1,25 @@
+using SymbolicLimits, SymbolicUtils
+using Test
+
+let limit = ((args...) -> SymbolicLimits.limit_inf(args...)[1]),
+        get_series_term = ((args...) -> SymbolicLimits.get_series_term(args..., Set{Any}())),
+        mrv_join = ((args...) -> SymbolicLimits.mrv_join(args..., Set{Any}())),
+        zero_equivalence = ((args...) -> SymbolicLimits.zero_equivalence(args..., Set{Any}())),
+        signed_limit = ((args...) -> SymbolicLimits.signed_limit_inf(args..., Set{Any}()))
+
+    @syms x::Real ω::Real
+    @test limit(-1 / x, x) === 0
+    @test limit(-x / log(x), x) === -Inf
+    @test unwrap_const(only(mrv_join(x)([exp(x)], [x])) - exp(x)) === 0
+    @test signed_limit(exp(exp(-x)) - 1, x) == (0, 1)
+    @test limit(exp(x + exp(-x)) - exp(x), x) == 1
+    @test limit(x^7 / exp(x), x) == 0
+    @test limit(x^70000 / exp(x), x) == 0
+    @test !zero_equivalence(get_series_term(log(x / ω), ω, -x, 0) - log(x / ω))
+    @test get_series_term(1 / ω, ω, -x, 0) == 0
+    @test limit(x^2 / (x^2 + log(x)), x) == 1
+    @test get_series_term(exp(ω), ω, -x, 2) == 1 / 2
+    @test zero_equivalence(1.0 - exp(-x + exp(log(x)))) # sus b.c. domain is not R, but okay
+    @test limit(x + log(x) - exp(exp(1 / x + log(log(x)))), x) == 0
+    @test limit(log(log(x * exp(x * exp(x)) + 1)) - exp(exp(log(log(x)) + 1 / x)), x) == 0
+end

--- a/test/gruntz_thesis.jl
+++ b/test/gruntz_thesis.jl
@@ -1,0 +1,18 @@
+using SymbolicLimits, SymbolicUtils
+using Test
+
+let
+    @syms x::Real h::Real
+    @test limit(exp(x + exp(-x)) - exp(x), x, Inf)[1] == 1
+    @test limit(x^7 / exp(x), x, Inf)[1] == 0
+    @test_broken limit((arccos(x + h) - arccos(x)) / h, h, 0, :right)[1] == _unknown_
+    @test_broken limit(1 / (x^log(log(log(log(1 / x - 1))))), x, 0, :right)[1] == Inf
+    @test_broken limit((erf(x - exp(-exp(x))) - erf(x)) * exp(exp(x)) * exp(x^2), x, Inf)[1] ≈
+        -2 / √π
+    @test_broken limit(exp(csc(x)) / exp(cot(x)), x, 0)[1] == 1
+    @test_broken limit(exp(x) * (sin(1 / x + exp(-x)) - sin(1 / x)), x, Inf)[1] == 1
+    @test limit(log(log(x * exp(x * exp(x)) + 1)) - exp(exp(log(log(x)) + 1 / x)), x, Inf)[1] ==
+        0
+    @test limit(2exp(-x) / exp(-x), x, 0)[1] == 2
+    @test_broken limit(exp(csc(x)) / exp(cot(x)), x, 0)[1] == 1
+end

--- a/test/limits_approaching_neg_inf.jl
+++ b/test/limits_approaching_neg_inf.jl
@@ -1,0 +1,10 @@
+using SymbolicLimits, SymbolicUtils
+using Test
+
+@syms x::Real
+# x * exp(x) -> 0 as x -> -Inf because exp(x) dominates
+@test limit(x * exp(x), x, -Inf)[1] == 0
+# exp(x) -> 0 as x -> -Inf
+@test limit(exp(x), x, -Inf)[1] == 0
+# x^2 * exp(x) -> 0 as x -> -Inf
+@test limit(x^2 * exp(x), x, -Inf)[1] == 0

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SymbolicLimits = "19f23fe9-fdab-4a78-91af-e7b7767979c3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -11,4 +12,5 @@ SymbolicLimits = {path = "../.."}
 [compat]
 JET = "0.9, 0.10, 0.11"
 Pkg = "1"
+SafeTestsets = "0.1, 1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,13 +1,13 @@
-using SymbolicLimits
-using Test
-using Aqua
-using JET
+using SafeTestsets
 
-@testset "Code quality (Aqua.jl)" begin
+@safetestset "Code quality (Aqua.jl)" begin
+    using SymbolicLimits
+    using Aqua
     Aqua.test_all(SymbolicLimits, deps_compat = false, ambiguities = false)
     Aqua.test_deps_compat(SymbolicLimits, check_extras = false)
 end
 
-@testset "Static analysis (JET.jl)" begin
+@safetestset "Static analysis (JET.jl)" begin
+    using JET
     JET.report_package("SymbolicLimits"; target_defined_modules = true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using SymbolicLimits, SymbolicUtils
+using SafeTestsets
 using Test
 
 const GROUP = get(ENV, "GROUP", "All")
@@ -13,165 +14,24 @@ end
 
 if GROUP == "All" || GROUP == "Core"
     @testset "SymbolicLimits.jl" begin
-        @testset "Tests that failed during initial development phase 1" begin
-            let
-                @syms x::Real y::Real ω::Real
-                @test SymbolicLimits.zero_equivalence(x * (x + y) - x - x * y + x - x * (x + 1) + x, Set{Any}())
-                @test_broken SymbolicLimits.zero_equivalence(exp((x + 1) * x - x * x - x) - 1, Set{Any}())
-
-                @test SymbolicLimits.get_leading_exponent(x^2, x, nothing, Set{Any}()) == 2
-                @test SymbolicLimits.get_series_term(log(exp(x)), x, nothing, 1, Set{Any}()) ==
-                    1
-                @test SymbolicLimits.get_series_term(log(exp(x)), x, -x, 0, Set{Any}()) == 0
-                @test SymbolicLimits.get_series_term(log(exp(x)), x, nothing, 2, Set{Any}()) ==
-                    0
-
-                # F = exp(x+exp(-x))-exp(x)
-                # Ω = {exp(x + exp(-x)), exp(x), exp(-x)}
-                # Topo-sort Ω by containment
-                # Take a smallest element of Ω and call it ω.
-                # ω = exp(-x)
-                # From largest to smallest, rewrite elements f ∈ Ω in terms of ω in the form
-                # Assume f is of the form exp(s) and ω is of the form exp(t).
-                # -- Recursively compute c = lim(s/t)
-                # f = f*ω^c/ω^c = exp(log(f)-c*log(ω))*ω^c = exp(s-ct)*ω^c
-
-                # f = exp(x+exp(-x))
-                # s = x+exp(-x)
-                # t = -x
-                # c = lim(s/t) = lim((x+exp(-x))/-x) = -1
-                # f = exp(s-ct)*ω^c = exp(x+exp(-x)-c*t)*ω^-1 = exp(exp(-x))/ω
-
-                @test SymbolicLimits.zero_equivalence(
-                    SymbolicLimits.rewrite(exp(x + exp(-x)), ω, -x, x, Set{Any}()) -
-                        exp(exp(-x)) / ω,
-                    Set{Any}()
-                ) # it works if you define `limit(args...) = -1`
-
-                # F = exp(exp(-x))/ω - exp(x)
-
-                # f = exp(x)
-                # s = x
-                # t = -x
-                # c = -1
-                # f = exp(s-ct)*ω^c = exp(x-c*t)*ω^-1 = exp(0)/ω = 1/ω
-
-                # F = exp(exp(-x))/ω - 1/ω
-
-                # ...
-
-                # F = exp(ω)/ω - 1/ω
-                let F = exp(ω) / ω - 1 / ω, h = -x
-                    @test SymbolicLimits.get_leading_exponent(F, ω, h, Set{Any}()) == 0
-                    @test SymbolicLimits.get_series_term(F, ω, h, 0, Set{Any}()) == 1 # the correct final answer
-                end
-
-                function test(expr, leading_exp, series, sym = x)
-                    lt = SymbolicLimits.get_leading_exponent(expr, sym, nothing, Set{Any}())
-                    @test lt === leading_exp
-                    for (i, val) in enumerate(series)
-                        @test SymbolicLimits.get_series_term(
-                            expr, sym, nothing, lt + i - 1, Set{Any}()
-                        ) === val
-                    end
-                    for i in (leading_exp - 10):(leading_exp - 1)
-                        @test SymbolicLimits.get_series_term(
-                            expr, sym, nothing, i, Set{Any}()
-                        ) === 0
-                    end
-                end
-                test(x, 1, [1, 0, 0, 0, 0, 0])
-                test(x^2, 2, [1, 0, 0, 0, 0, 0])
-                test(x^2 + x, 1, [1, 1, 0, 0, 0, 0])
-
-                @test SymbolicLimits.recursive([1, [2, 3]]) do f, arg
-                    arg isa AbstractArray ? sum(f, arg) : arg
-                end == 6
-
-                @test unwrap_const(
-                    only(SymbolicLimits.most_rapidly_varying_subexpressions(exp(x), x, Set{Any}())) -
-                        exp(x)
-                ) === 0 # works if you define `limit(args...) = Inf`
-                @test all(i -> i === x, SymbolicLimits.most_rapidly_varying_subexpressions(x + 2(x + 1), x, Set{Any}())) # works if you define `limit(args...) = 1`
-
-                @test SymbolicLimits.log_exp_simplify(x) === x
-                @test SymbolicLimits.zero_equivalence(
-                    SymbolicLimits.log_exp_simplify(exp(x)) -
-                        exp(x), Set{Any}()
-                )
-                @test SymbolicLimits.zero_equivalence(
-                    SymbolicLimits.log_exp_simplify(exp(log(x))) - exp(log(x)), Set{Any}()
-                )
-                @test SymbolicLimits.log_exp_simplify(log(exp(x))) === x
-                @test SymbolicLimits.zero_equivalence(
-                    SymbolicLimits.log_exp_simplify(log(exp(log(x)))) - log(x), Set{Any}()
-                )
-                @test unwrap_const(SymbolicLimits.log_exp_simplify(log(exp(1 + x))) - (1 + x)) === 0
-                @test SymbolicLimits.log_exp_simplify(log(log(exp(exp(x))))) === x
-                @test SymbolicLimits.log_exp_simplify(log(exp(log(exp(x))))) === x
-            end
+        @safetestset "Tests that failed during initial development phase 1" begin
+            include("development_phase_1.jl")
         end
 
-        @testset "Tests that failed during initial development phase 2" begin
-            let limit = ((args...) -> SymbolicLimits.limit_inf(args...)[1]),
-                    get_series_term = ((args...) -> SymbolicLimits.get_series_term(args..., Set{Any}())),
-                    mrv_join = ((args...) -> SymbolicLimits.mrv_join(args..., Set{Any}())),
-                    zero_equivalence = ((args...) -> SymbolicLimits.zero_equivalence(args..., Set{Any}())),
-                    signed_limit = ((args...) -> SymbolicLimits.signed_limit_inf(args..., Set{Any}()))
-
-                @syms x::Real ω::Real
-                @test limit(-1 / x, x) === 0
-                @test limit(-x / log(x), x) === -Inf
-                @test unwrap_const(only(mrv_join(x)([exp(x)], [x])) - exp(x)) === 0
-                @test signed_limit(exp(exp(-x)) - 1, x) == (0, 1)
-                @test limit(exp(x + exp(-x)) - exp(x), x) == 1
-                @test limit(x^7 / exp(x), x) == 0
-                @test limit(x^70000 / exp(x), x) == 0
-                @test !zero_equivalence(get_series_term(log(x / ω), ω, -x, 0) - log(x / ω))
-                @test get_series_term(1 / ω, ω, -x, 0) == 0
-                @test limit(x^2 / (x^2 + log(x)), x) == 1
-                @test get_series_term(exp(ω), ω, -x, 2) == 1 / 2
-                @test zero_equivalence(1.0 - exp(-x + exp(log(x)))) # sus b.c. domain is not R, but okay
-                @test limit(x + log(x) - exp(exp(1 / x + log(log(x)))), x) == 0
-                @test limit(log(log(x * exp(x * exp(x)) + 1)) - exp(exp(log(log(x)) + 1 / x)), x) == 0
-            end
+        @safetestset "Tests that failed during initial development phase 2" begin
+            include("development_phase_2.jl")
         end
 
-        @testset "Examples from Gruntz's 1996 thesis" begin
-            let
-                @syms x::Real h::Real
-                @test limit(exp(x + exp(-x)) - exp(x), x, Inf)[1] == 1
-                @test limit(x^7 / exp(x), x, Inf)[1] == 0
-                @test_broken limit((arccos(x + h) - arccos(x)) / h, h, 0, :right)[1] == _unknown_
-                @test_broken limit(1 / (x^log(log(log(log(1 / x - 1))))), x, 0, :right)[1] == Inf
-                @test_broken limit((erf(x - exp(-exp(x))) - erf(x)) * exp(exp(x)) * exp(x^2), x, Inf)[1] ≈
-                    -2 / √π
-                @test_broken limit(exp(csc(x)) / exp(cot(x)), x, 0)[1] == 1
-                @test_broken limit(exp(x) * (sin(1 / x + exp(-x)) - sin(1 / x)), x, Inf)[1] == 1
-                @test limit(log(log(x * exp(x * exp(x)) + 1)) - exp(exp(log(log(x)) + 1 / x)), x, Inf)[1] ==
-                    0
-                @test limit(2exp(-x) / exp(-x), x, 0)[1] == 2
-                @test_broken limit(exp(csc(x)) / exp(cot(x)), x, 0)[1] == 1
-            end
+        @safetestset "Examples from Gruntz's 1996 thesis" begin
+            include("gruntz_thesis.jl")
         end
 
-        @testset "Two sided limits" begin
-            @syms x
-            limit(x + 1, x, 0)[1] == 1
-            limit(x, x, 0)[1] == 0
-            @test_throws ArgumentError limit(1 / x, x, 0)
-            @test limit(1 / x, x, 0, :left)[1] == -Inf
-            @test limit(1 / x, x, 0, :right)[1] == Inf
+        @safetestset "Two sided limits" begin
+            include("two_sided_limits.jl")
         end
 
-        @testset "Limits approaching -Inf (issue #13)" begin
-            @syms x::Real
-            # x * exp(x) -> 0 as x -> -Inf because exp(x) dominates
-            @test limit(x * exp(x), x, -Inf)[1] == 0
-            # exp(x) -> 0 as x -> -Inf
-            @test limit(exp(x), x, -Inf)[1] == 0
-            # x^2 * exp(x) -> 0 as x -> -Inf
-            @test limit(x^2 * exp(x), x, -Inf)[1] == 0
+        @safetestset "Limits approaching -Inf (issue #13)" begin
+            include("limits_approaching_neg_inf.jl")
         end
     end
 end

--- a/test/two_sided_limits.jl
+++ b/test/two_sided_limits.jl
@@ -1,0 +1,9 @@
+using SymbolicLimits, SymbolicUtils
+using Test
+
+@syms x
+limit(x + 1, x, 0)[1] == 1
+limit(x, x, 0)[1] == 0
+@test_throws ArgumentError limit(1 / x, x, 0)
+@test limit(1 / x, x, 0, :left)[1] == -Inf
+@test limit(1 / x, x, 0, :right)[1] == Inf


### PR DESCRIPTION
## Summary

Canonicalize the test suite so each independent test unit runs in its own module via `@safetestset`, matching the canonical SciML structure (isolation between tests + world-age safety, as in OrdinaryDiffEq).

### Core group
The five inner units (the two development-phase regression sets, the Gruntz thesis examples, the two-sided limits, and the issue-#13 `-Inf` limits) are extracted from the monolithic `runtests.jl` into self-contained files that each carry their own `using` lines. `runtests.jl` now dispatches each as `@safetestset "X" begin include("x.jl") end` inside the outer grouping `@testset "SymbolicLimits.jl"`.

The `include()` form (rather than an inline `@safetestset` body) is required because the bodies use the SymbolicUtils `@syms` macro: a `@safetestset` body expands to a fresh module that is macroexpanded as one unit, so an in-body `using SymbolicUtils` would not take effect before `@syms` is resolved. As top-level statements in the included files, `using` runs before `@syms` is reached. The phase-1/phase-2 units also use the bare `unwrap_const` (from SymbolicUtils), so each file carries `using SymbolicUtils`.

### QA group
The two `qa.jl` units (Aqua, JET) become `@safetestset` blocks, each with its own `using`. They use no package-defined macros, so inline bodies are fine. The `GROUP` dispatch ladder and the `test/qa` env activation are unchanged.

### Deps
`SafeTestsets` added to the root `[extras]`/`[targets].test` + `[compat]`, and to `test/qa/Project.toml` (the QA group activates its own env) + its `[compat]`.

## Behavior preservation

No test logic changed — same units, same assertions, same `@test_broken` set. Verified locally (Julia 1.11, SymbolicUtils v4.35.0):

- `GROUP=Core`: **94 Pass, 7 Broken, 101 Total** — identical to the unmodified base branch (also 94/7/101).
- `GROUP=QA`: Aqua **9/9 pass**, JET report clean.

Runic applied to the changed files; `runic --check` passes.

---

This PR is a draft. Please ignore until reviewed by @ChrisRackauckas.