### PR TITLE
Fix docs deploy: grant contents: write so gh-pages push succeeds

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,6 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
 
+# Required so the reusable workflow's GITHUB_TOKEN can push to gh-pages when no
+# DOCUMENTER_KEY SSH secret is configured. Without this the caller token is
+# read-only and Documenter's `git push` to gh-pages fails with HTTP 403.
+permissions:
+  contents: write
+  statuses: write
+
 jobs:
   build-and-deploy-docs:
     name: "Documentation"


### PR DESCRIPTION
## Problem

The only failing check on `main` is **Documentation / Build and Deploy Documentation**. The docs **build succeeds** — the failure is the final deploy step:

```
fatal: unable to access 'https://github.com/SciML/SymbolicLimits.jl.git/': The requested URL returned error: 403
Error: Failed to push:
   failed process: Process(`git push -q upstream HEAD:gh-pages`) ... ProcessExited(128)
```

## Root cause

Commit `fb8ffe7` ("Migrate CI to centralized SciML reusable workflows") replaced the old in-`CI.yml` docs job with a caller of `SciML/.github/.github/workflows/documentation.yml@v1`.

The old docs job carried:
```yaml
permissions:
  contents: write
  statuses: write
```
and deployed successfully via `GITHUB_TOKEN` (gh-pages last updated fine pre-migration, "build based on 0ff0262").

The new caller declared **no `permissions:` block**, and the reusable workflow itself declares none either, so the caller's `GITHUB_TOKEN` defaults to read-only. This repo has **no `DOCUMENTER_KEY` SSH secret** (the job log shows `DOCUMENTER_KEY:` empty and `Deploying: ✔` via `GITHUB_TOKEN`), so Documenter deploys over HTTPS with the token — and a read-only token cannot push to `gh-pages` → HTTP 403.

(Repos like LinearSolve.jl use the identical caller and deploy green because they have a `DOCUMENTER_KEY` secret, which bypasses `GITHUB_TOKEN` push permissions.)

## Fix

Restore `permissions: contents: write` (+ `statuses: write`) on the caller workflow — exactly what the pre-migration docs job had. Caller permissions propagate to the reusable workflow's `GITHUB_TOKEN`, restoring the working token-based deploy without requiring a secret.

## Verification

Built locally on Julia 1.12.6 (the version CI used):
- `julia --project=docs docs/make.jl` exits 0 — doctests pass, document checks pass, HTML renders.
- `deploydocs` correctly skips deployment off-CI ("could not auto-detect the building environment"), confirming the build path is healthy and only the CI deploy push was failing.

The 403 is a CI-only token-permission issue not reproducible locally; this change targets exactly that.

Please ignore until reviewed by @ChrisRackauckas