### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Manifest.toml
 /docs/Manifest.toml
 /docs/build/
+/test/qa/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 [compat]
 Aqua = "0.8"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 SymbolicUtils = "4"
 TermInterface = "2.0"
 Test = "1"

--- a/src/limits.jl
+++ b/src/limits.jl
@@ -28,9 +28,9 @@
 # expansion of `g` in terms of `x`, how do we get a series expansion of `log(g)` in terms of
 # `x`?
 
-using SymbolicUtils
+using SymbolicUtils: SymbolicUtils, simplify, unwrap_const
 using SymbolicUtils: BasicSymbolic, isconst, isterm, issym, isaddmul, isdiv, isadd, ismul, symtype
-using TermInterface
+using TermInterface: TermInterface, arguments, iscall, operation
 
 """
     is_exp(expr)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -10,8 +10,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SymbolicLimits = {path = "../.."}
 
 [compat]
+Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -5,19 +5,17 @@ run_qa(
     SymbolicLimits;
     explicit_imports = true,
     ei_kwargs = (;
-        # Non-public names from SymbolicUtils / Base.Iterators accessed qualified;
-        # they go public as those base libs declare them public.
+        # Non-public names from SymbolicUtils accessed qualified;
+        # they go public as SymbolicUtils declares them public.
         all_qualified_accesses_are_public = (;
             ignore = (
-                :ShapeVecT, :Sym, :_iszero,   # SymbolicUtils
-                :peel,                         # Base.Iterators
+                :ShapeVecT, :_iszero,   # SymbolicUtils
             ),
         ),
         # Non-public names explicitly imported from SymbolicUtils.
         all_explicit_imports_are_public = (;
             ignore = (
-                :BasicSymbolic, :isadd, :isaddmul, :isconst, :isdiv,
-                :ismul, :issym, :isterm, :symtype,   # SymbolicUtils
+                :isaddmul, :isconst,   # SymbolicUtils
             ),
         ),
     ),

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,13 +1,24 @@
-using SymbolicLimits
-using Test
-using Aqua
+using SciMLTesting, SymbolicLimits, Test
 using JET
 
-@testset "Code quality (Aqua.jl)" begin
-    Aqua.test_all(SymbolicLimits, deps_compat = false, ambiguities = false)
-    Aqua.test_deps_compat(SymbolicLimits, check_extras = false)
-end
-
-@testset "Static analysis (JET.jl)" begin
-    JET.report_package("SymbolicLimits"; target_defined_modules = true)
-end
+run_qa(
+    SymbolicLimits;
+    explicit_imports = true,
+    ei_kwargs = (;
+        # Non-public names from SymbolicUtils / Base.Iterators accessed qualified;
+        # they go public as those base libs declare them public.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :ShapeVecT, :Sym, :_iszero,   # SymbolicUtils
+                :peel,                         # Base.Iterators
+            ),
+        ),
+        # Non-public names explicitly imported from SymbolicUtils.
+        all_explicit_imports_are_public = (;
+            ignore = (
+                :BasicSymbolic, :isadd, :isaddmul, :isconst, :isdiv,
+                :ismul, :issym, :isterm, :symtype,   # SymbolicUtils
+            ),
+        ),
+    ),
+)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Brings this repo's QA onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled.

## Changes
- **`test/qa/qa.jl`**: hand-rolled `Aqua.test_all` + `JET.report_package` body replaced with `run_qa(SymbolicLimits; explicit_imports = true, ei_kwargs = ...)`. Aqua + ExplicitImports come from SciMLTesting's own deps; JET is enabled via `using JET`.
- **`src/limits.jl`**: the 7 implicit imports made explicit (`using SymbolicUtils: SymbolicUtils, simplify, unwrap_const` and `using TermInterface: TermInterface, arguments, iscall, operation`).
- **`test/qa/Project.toml`**: `SciMLTesting` compat → `"1.6"`; added `Aqua` compat (Aqua stays a direct QA dep so the ambiguities sub-check's child-process can import it). ExplicitImports is transitive via SciMLTesting and not listed.
- **`Project.toml`**: `SciMLTesting` compat → `"1.6"`.
- **`.gitignore`**: ignore `test/qa/Manifest.toml`.

## ExplicitImports findings
- `no_implicit_imports`: **FIXED** — 7 implicit names (`SymbolicUtils`, `simplify`, `unwrap_const`; `TermInterface`, `arguments`, `iscall`, `operation`) made explicit. Passes.
- `no_stale_explicit_imports`, `all_explicit_imports_via_owners`, `all_qualified_accesses_via_owners`: pass unchanged.
- `all_qualified_accesses_are_public`: **IGNORED** non-public names — `ShapeVecT`, `Sym`, `_iszero` (SymbolicUtils), `peel` (Base.Iterators). They go public as those base libs declare them.
- `all_explicit_imports_are_public`: **IGNORED** non-public SymbolicUtils names — `BasicSymbolic`, `isadd`, `isaddmul`, `isconst`, `isdiv`, `ismul`, `issym`, `isterm`, `symtype`.
- No `ei_broken` needed (0 broken).

## Aqua / JET
Both formerly-disabled Aqua sub-checks (`ambiguities`, `deps_compat`) now pass, so they are re-enabled (no `aqua_kwargs`/`aqua_broken`). JET runs the standard hard `test_package` with 0 reports (no `jet_broken`).

## Verification (local, Julia 1.10, released SciMLTesting 1.6.0)
- QA group: **18/18 pass, 0 Fail/Error/Broken**.
- Core group: still passes (`SymbolicLimits tests passed`), no regression from the explicit-import change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)