### PR TITLE
Update SciMLTesting QA docs checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 [compat]
 Aqua = "0.8"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.6"
+SciMLTesting = "2.1"
 SymbolicUtils = "4"
 TermInterface = "2.0"
 Test = "1"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SymbolicLimits = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.6"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -4,6 +4,7 @@ using JET
 run_qa(
     SymbolicLimits;
     explicit_imports = true,
+    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         # Non-public names from SymbolicUtils accessed qualified;
         # they go public as SymbolicUtils declares them public.


### PR DESCRIPTION
Ignore this draft PR until reviewed by @ChrisRackauckas.

## Summary
- Update root and QA SciMLTesting compat to 2.1.
- Use SciMLTesting's shared public API docs QA path; rendered docs checks are enabled where package docs exist.
- Add or render missing public API docstrings/docs entries where needed and remove stale repo-local public-docs QA where present.

## Local Validation
- PASS: timeout 3600 ~/.juliaup/bin/julia +1.10 TOML parse over root/test/docs TOML files.
- PASS: no absolute QA [sources] paths and no test/Project.toml in this repo.
- PASS: timeout 3600 ~/.juliaup/bin/julia +1.12 -m Runic --check <changed .jl files>.
- PASS: GROUP=QA timeout 3600 ~/.juliaup/bin/julia +1.12 --project=. -e "using Pkg; Pkg.test()".
- PASS: timeout 3600 ~/.juliaup/bin/julia +1.12 --project=. -e "using Pkg; Pkg.test()".

