### PR TITLE
Release prep: bump SymbolicLimits to 1.1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicLimits"
 uuid = "19f23fe9-fdab-4a78-91af-e7b7767979c3"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test-scaffolding changes since 1.1.2 (SciMLTesting compat floor bump for the test-only QA dependency and enabling the rendered-API-docs QA check). No runtime API or behavior changes.