### PR TITLE
Remove redundant QA self source

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SymbolicLimits = "19f23fe9-fdab-4a78-91af-e7b7767979c3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SymbolicLimits = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- Remove the redundant package-under-test `[sources]` path entry from `test/qa/Project.toml`.
- Keep the SciMLTesting 2.1/public API QA setup unchanged.

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia --project=@runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check test/qa/Project.toml`\n- `GROUP=QA timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`