### PR TITLE
Release prep: bump version to 1.1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicLimits"
 uuid = "19f23fe9-fdab-4a78-91af-e7b7767979c3"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
-version = "1.1.3"
+version = "1.1.4"
 
 [deps]
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"


### PR DESCRIPTION
## Summary
Bumps the package version from 1.1.3 to 1.1.4 to release the one unreleased commit since the last registered version.

Change since 1.1.3 (commit eefcdec, which matches the registered git-tree-sha1 for 1.1.3 exactly):

- #45 "Remove redundant QA self source" — removes a redundant `[sources]` entry (`SymbolicLimits = {path = "../.."}`) from `test/qa/Project.toml`. Test/QA infrastructure only, no source code or public API changes.

## Bump type
PATCH (1.1.3 -> 1.1.4): the only change is a test-configuration cleanup with no effect on package behavior or public API.

## Compat
No `[compat]` changes needed — no new dependencies or dependency-version-gated features were introduced.