### PR TITLE
Add PrecompileTools workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
 version = "1.1.5"
 
 [deps]
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [compat]
 Aqua = "0.8"
+PrecompileTools = "1.2.1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
 SymbolicUtils = "4"

--- a/src/SymbolicLimits.jl
+++ b/src/SymbolicLimits.jl
@@ -1,5 +1,8 @@
 module SymbolicLimits
 
+using PrecompileTools: @compile_workload, @setup_workload
+using SymbolicUtils: @syms
+
 export limit
 
 include("limits.jl")
@@ -77,5 +80,7 @@ function limit(expr::BasicSymbolic, var::BasicSymbolic, h, side::Symbol)
         end
     end
 end
+
+include("precompilation.jl")
 
 end

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,0 +1,15 @@
+@setup_workload begin
+    @syms x::Real
+    finite_expr = x + 1
+    reciprocal_expr = 1 / x
+    positive_inf_expr = x^2 / exp(x)
+    negative_inf_expr = x * exp(x)
+
+    @compile_workload begin
+        limit(finite_expr, x, 0)
+        limit(reciprocal_expr, x, 0, :left)
+        limit(reciprocal_expr, x, 0, :right)
+        limit(positive_inf_expr, x, Inf)
+        limit(negative_inf_expr, x, -Inf)
+    end
+end

--- a/test/precompile_workload.jl
+++ b/test/precompile_workload.jl
@@ -1,0 +1,12 @@
+using SymbolicLimits, SymbolicUtils
+using Test
+
+@syms x::Real
+
+@testset "Precompile workload" begin
+    @test limit(x + 1, x, 0)[1] == 1
+    @test limit(1 / x, x, 0, :left)[1] == -Inf
+    @test limit(1 / x, x, 0, :right)[1] == Inf
+    @test limit(x^2 / exp(x), x, Inf)[1] == 0
+    @test limit(x * exp(x), x, -Inf)[1] == 0
+end


### PR DESCRIPTION
## Summary
Adds a PrecompileTools workload covering representative public APIs so the package common execution path is compiled during precompilation.

## Verification
The branch was validated locally with package load/precompile, a focused workload smoke test, and repository checks where available. Runic, typos, and git diff --check were checked for the change.

## Known limitations
No additional limitation was observed in the focused verification.

This draft should be ignored until reviewed by @ChrisRackauckas.